### PR TITLE
Fix validation calls to prevent automatic downloads

### DIFF
--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -586,6 +586,7 @@ fetch_file_from_ena_auto() {
     local destFile=$2
     local retries=${3:-3}
     local library=${4:-''}
+    local validateOnly=${5:-''}
 
     check_variables "enaFile" "destFile"
     
@@ -609,7 +610,7 @@ fetch_file_from_ena_auto() {
         for method in $methods; do
             echo "Fetching $enaFile using method $method, attempt $i"
             function="fetch_file_from_ena_over_$method"
-            $function $enaFile $destFile 1  
+            $function $enaFile $destFile 1 "$library" "$validateOnly" 
             
             exitCode=$?
             if [ $exitCode -eq 0 ]; then 
@@ -630,8 +631,8 @@ fetch_file_from_ena_over_ssh() {
     local destFile=$2
     local retries=${3:-3}
     local library=${4:-''}
-    local status=${5:-'public'}
-    local validateOnly=${6:-''}
+    local validateOnly=${5:-''}
+    local status=${6:-'public'}
 
     check_variables "enaFile" "destFile"
 
@@ -724,6 +725,7 @@ fetch_file_from_ena_over_http() {
     local destFile=$2
     local retries=${3:-3}
     local library=${4:-''}
+    local validateOnly=${5:-''}
 
     check_variables "enaFile" "destFile"
 
@@ -731,7 +733,7 @@ fetch_file_from_ena_over_http() {
     local enaPath=$(convert_ena_fastq_to_uri $enaFile http $library)
     
     # Fetch
-    fetch_file_by_wget $enaPath $destFile $retries http ena
+    fetch_file_by_wget $enaPath $destFile $retries http ena $validateOnly
 }
 
 fetch_file_from_ena_over_ftp() {
@@ -739,6 +741,7 @@ fetch_file_from_ena_over_ftp() {
     local destFile=$2
     local retries=${3:-3}
     local library=${4:-''}
+    local validateOnly=${5:-''}
 
     check_variables "enaFile" "destFile"
     
@@ -746,7 +749,7 @@ fetch_file_from_ena_over_ftp() {
     local enaPath=$(convert_ena_fastq_to_uri $enaFile ftp $library)
 
     # Fetch
-    fetch_file_by_wget $enaPath $destFile $retries ftp ena
+    fetch_file_by_wget $enaPath $destFile $retries ftp ena $validateOnly
 }
 
 # Convert an SRA-style file to its path on the ENA node 
@@ -905,7 +908,7 @@ fetch_library_files_from_ena() {
                 fetchMethod="fetch_file_from_ena_over_$method"
             fi
 
-            $fetchMethod $l $outputDir/$fileName $retries $library $status
+            $fetchMethod $l $outputDir/$fileName $retries $library "" $status
             local returnCode=$?
             if [ $returnCode -ne 0 ]; then
                 return $returnCode

--- a/fetchFastq.sh
+++ b/fetchFastq.sh
@@ -157,7 +157,7 @@ elif [ "$method" == 'ena_ftp' ]; then
 elif [ "$method" == 'ena_auto' ]; then
     
     # Auto-select the ENA method get the file
-    fetch_file_from_ena_auto $file_or_uri $target $ENA_RETRIES
+    fetch_file_from_ena_auto $file_or_uri $target $ENA_RETRIES "$library" "$validateOnly"
     fetch_status=$?    
 else
     echo "Don't know how to get $file_or_uri from $fileSource with $method" 1>&2

--- a/fetchFastq.sh
+++ b/fetchFastq.sh
@@ -139,19 +139,19 @@ elif [ "$method" == 'dir' ]; then
 
 elif [ "$method" == 'ena_ssh' ]; then
     # Use an SSH connection to retrieve the file
-    fetch_file_from_ena_over_ssh $file_or_uri $target $ENA_RETRIES $library $status 
+    fetch_file_from_ena_over_ssh $file_or_uri $target $ENA_RETRIES $library "$validateOnly" $status
     fetch_status=$?    
 
 elif [ "$method" == 'ena_http' ]; then
     
     # Use the HTTP endpoint to get the file
-    fetch_file_from_ena_over_http $file_or_uri $target $ENA_RETRIES $library
+    fetch_file_from_ena_over_http $file_or_uri $target $ENA_RETRIES $library "$validateOnly"
     fetch_status=$?    
 
 elif [ "$method" == 'ena_ftp' ]; then
     
     # Use the FTP wget to get the file
-    fetch_file_from_ena_over_ftp $file_or_uri $target $ENA_RETRIES $library
+    fetch_file_from_ena_over_ftp $file_or_uri $target $ENA_RETRIES $library "$validateOnly"
     fetch_status=$?    
 
 elif [ "$method" == 'ena_auto' ]; then

--- a/fetchFastq.sh
+++ b/fetchFastq.sh
@@ -173,7 +173,7 @@ if [ -n "$validateOnly" ]; then
     actioned='validated'
 fi
 
-if [ $fetch_status -eq 0 ] && [ -s "$target" ]; then
+if [[ $fetch_status -eq 0  && ( -s "$target" ||  -n "$validateOnly" ) ]]; then
     echo "Successfully ${actioned} $file_or_uri from $fileSource with $method"
 else
     echo -n "Failed to $action $file_or_uri from $fileSource with $method: " 1>&2


### PR DESCRIPTION
These fixes properly enable the 'validate only' mode I started, but apparently never finished previously. The appropriate argument needs to get passed through the various functions, in particular from fetchFastq.sh, which they were not previously.