### PR TITLE
Return error when no files match library in source directory

### DIFF
--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -186,6 +186,16 @@ link_local_dir() {
 
     if [ -n "$library" ]; then
         dirFiles=$(echo -e "$dirFiles" | grep $library)
+        if [ $? -ne 0 ]; then
+            echo "No files matching $library in source directory $sourceDir" 1>&2
+            return 8
+        fi
+    fi
+
+    # If library is specified, only link files maching the pattern
+
+    if [ -n "$library" ]; then
+        dirFiles=$(echo -e "$dirFiles" | grep $library)
     fi
 
     # Do the linking

--- a/fetchEnaLibraryFastqs.sh
+++ b/fetchEnaLibraryFastqs.sh
@@ -75,6 +75,8 @@ if [ $fetchStatus -eq 0 ]; then
     echo "Successfully downloaded $library from ENA with $method"
 elif [ $fetchStatus -eq 2 ]; then 
     echo  "Skipped download of already existing $library files from ENA with $method" 
+elif [ $fetchStatus -eq 8 ]; then
+    echo "$library files could not be linked from $fileSource"
 else
     echo -n "Failed to download $library files from ENA with $method: " 
     if [ $fetchStatus -eq 3 ]; then


### PR DESCRIPTION
This PR fixes issue of silent failure where files matching a library are not found in a provided source directory.