### PR TITLE
Fix library path routine for octal error issue

### DIFF
--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -279,6 +279,7 @@ time_since_last() {
         return 0
     else 
         # Just a really big number
+        touch $testfile
         echo 1000000000000
         return 1
     fi
@@ -363,20 +364,18 @@ fetch_file_by_wget() {
 
     local wgetTempFile=${destFile}.tmp
     rm -f $wgetTempFile
-
     local process_status=1
     for i in $(seq 1 $retries); do 
         if [ "$method" != '' ]; then
             wait_and_record ${source}_$method
         fi
-
         wget  -nv -c $sourceFile -O $wgetTempFile 
         if [ $? -eq 0 ]; then
             process_status=0
             break
         fi
     done
-    
+ 
     if [ $process_status -ne 0 ] || [ ! -s $wgetTempFile ] ; then
         echo "ERROR: Failed to retrieve $enaPath to ${destFile}" 1>&2
         rm -f $wgetTempFile 

--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -12,22 +12,21 @@ get_library_path() {
     local prefix=
     if ! [[ $subDir =~ "ENC" ]] && [[ -z "$forceShortForm" ]] ; then
         local num=${library:3}
-       
-        # ENA pattern is:
-        # 
-        # - 6-digit codes under e.g. SRR123456
-        # - 7-digit codes under e.g. 007/SRR1234567
-        # - 8-digit codes under e.g. 078/SRR12345678
-        #
-        # i.e. we zero-pad to three digits anything after and including the
-        # 10th digit
+        if [ $num -gt 1000000 ]; then
 
-        if [[ "$num" =~ ^[0-9]+$ ]]; then
-            if [ $num -gt 1000000 ]; then
-                digits=${library:9}
-                prefix="$(printf %03d  ${digits##+(0)})/"    
-            fi
-        fi 
+            # ENA pattern is:
+            # 
+            # - 6-digit codes under e.g. SRR123456
+            # - 7-digit codes under e.g. 007/SRR1234567
+            # - 8-digit codes under e.g. 078/SRR12345678
+            #
+            # i.e. we zero-pad to three digits anything after and including the
+            # 10th digit. Where we have e.g. '09' we need to strip leading
+            # zeros to prevent octal errors with bash.
+
+            digits=$(echo ${library:9} | sed 's/^0*//');
+            prefix="$(printf %03d $digits)/"
+        fi
     fi
     echo "${rootDir}/${subDir}/${prefix}${library}/${library}"
 }


### PR DESCRIPTION
Just a tiny fix to address an octal error in Bash when calculating SRA paths.