### PR TITLE
Require gzips to pass integrity test with wget

### DIFF
--- a/.github/workflows/download.yml
+++ b/.github/workflows/download.yml
@@ -16,31 +16,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: install mamba
+        uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: test-environment.yml
+
       - name: Add workspace to path
         run: |
           echo "${GITHUB_WORKSPACE}" >> $GITHUB_PATH
 
-      - name: Cache conda
-        uses: actions/cache@v1
-        env:
-          # Increase this value to reset cache if etc/example-environment.yml has not changed
-          CACHE_NUMBER: 0
-        with:
-          path: ~/conda_pkgs_dir
-          key:
-            ${{ matrix.os }}-conda-${{ env.CACHE_NUMBER }}-${{hashFiles('test-environment.yml') }}
-      
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          activate-environment: test
-          environment-file: test-environment.yml
-          python-version: 3.6
-          channels: conda-forge,bioconda,defaults
-          allow-softlinks: true
-          channel-priority: flexible
-          show-channel-urls: true
-          use-only-tar-bz2: true
-      
       - name: Run tests
         run: |
           atlas-fastq-provider-post-install-tests.sh

--- a/atlas-fastq-provider-config.sh.default
+++ b/atlas-fastq-provider-config.sh.default
@@ -12,4 +12,4 @@ ENA_RETRIES=3
 ALLOWED_DOWNLOAD_METHODS='http ftp'
 ENA_SSH_USER=
 DCP_BUNDLE_URI=https://service.azul.data.humancellatlas.org/index/bundles/BUNDLE
-DCP_BUNDLE_CATALOGS='dcp1 dcp7
+DCP_BUNDLE_CATALOGS='dcp1 dcp7'

--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -374,7 +374,7 @@ fetch_file_by_wget() {
         
         # If this is a gzip file, we can test its integrity
 
-        $gzip_status = 0
+        gzip_status=0
         echo "$sourceFile" | grep '\.gz$' > /dev/null   
         if [ $? -eq 0 ]; then
             gzip -t $wgetTempFile > /dev/null

--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -374,7 +374,7 @@ fetch_file_by_wget() {
         
         # If this is a gzip file, we can test its integrity
 
-        gzip_status = 0
+        $gzip_status = 0
         echo "$sourceFile" | grep '\.gz$' > /dev/null   
         if [ $? -eq 0 ]; then
             gzip -t $wgetTempFile > /dev/null

--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -370,14 +370,25 @@ fetch_file_by_wget() {
             wait_and_record ${source}_$method
         fi
         wget  -nv -c $sourceFile -O $wgetTempFile 
+        wget_status = $?
+        
+        # If this is a gzip file, we can test its integrity
+
+        gzip_status = 0
+        echo "$sourceFile" | grep '\.gz$' > /dev/null   
         if [ $? -eq 0 ]; then
+            gzip -t $wgetTempFile > /dev/null
+            gzip_status = $?
+        fi 
+
+        if [ $wget_status -eq 0 ] && [ $gzip_status -eq 0 ]; then
             process_status=0
             break
         fi
     done
  
     if [ $process_status -ne 0 ] || [ ! -s $wgetTempFile ] ; then
-        echo "ERROR: Failed to retrieve $enaPath to ${destFile}" 1>&2
+        echo "ERROR: Failed to retrieve $sourceFile to ${destFile}" 1>&2
         rm -f $wgetTempFile 
         return 1
     else

--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -313,7 +313,7 @@ wait_and_record() {
     last_time=$(time_since_last $action)
     while [ $? -ne 0 ] || (( $(echo "$last_time < $fetchFreqMillis" |bc -l) )); do
         # Sleep for 1/100th of a second
-        usleep 10000 
+        sleep 0.01 
 
         # Check last_time again- other processes could have altered it
         last_time=$(time_since_last $action)
@@ -370,7 +370,7 @@ fetch_file_by_wget() {
             wait_and_record ${source}_$method
         fi
         wget  -nv -c $sourceFile -O $wgetTempFile 
-        wget_status = $?
+        wget_status=$?
         
         # If this is a gzip file, we can test its integrity
 
@@ -378,7 +378,7 @@ fetch_file_by_wget() {
         echo "$sourceFile" | grep '\.gz$' > /dev/null   
         if [ $? -eq 0 ]; then
             gzip -t $wgetTempFile > /dev/null
-            gzip_status = $?
+            gzip_status=$?
         fi 
 
         if [ $wget_status -eq 0 ] && [ $gzip_status -eq 0 ]; then

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -1,4 +1,8 @@
 name: test
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
 dependencies:
   - bats
   - coreutils


### PR DESCRIPTION
I'm experiencing a few corrupted files coming from the FIRE service. The gzip integrity check here will stop most of those polluting downstream steps (I've checked it works). 

I've also removed the use of deprecated 'usleep', corrected a mistake I made in the default config, and switched CI to use micromamba. 