### PR TITLE
Transfer remaining Fastq handling logic out of ISL

### DIFF
--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -1197,7 +1197,7 @@ fetch_library_files_from_ena() {
 
         # get base filenames to be checked
         uniq=($(printf "%s\n" "${filenames_arr[@]}" | sort -u | tr '\n' ' ' ))
-        printf "%s\n" "${uniq[@]}" 
+        #printf "%s\n" "${uniq[@]}" 
         
         for basefile in "${uniq[@]}"; do
 
@@ -1225,7 +1225,7 @@ fetch_library_files_from_ena() {
                         exit 1
                     else
                         if [ ! -s "${localFastqPath}_1.fastq" ] ||  [ ! -s "${localFastqPath}_2.fastq" ]; then
-                            rm -rf ${localFastqPath}*.fastq.gz
+                            rm -rf ${localFastqPath}*.fastq*
                             echo "ERROR: Failed to de-interleave, forward or reverse not generated"
                             exit 1
                         fi
@@ -1248,25 +1248,33 @@ fetch_library_files_from_ena() {
 
     else
         echo "single end"
-        if [ ! -s "${localFastqPath}.fastq.gz" ]; then
-            # ENA has a bug: 'For some reason we dump
-            # these runs differently as we expect a CONSENSUS to be dumped.  If
-            # there is no CONSENSUS table found inside cSRA container we dump runs
-            # as-is using --split-file option.' This results in single-end FASTQ
-            # files being named <run_id>_1.fastq.gz. They say they will fix it, but
-            # in the meantime, we need to use the following workaround.
+        # get base filenames to be checked
+        uniq=($(printf "%s\n" "${filenames_arr[@]}" | sort -u | tr '\n' ' ' ))
+        #printf "%s\n" "${uniq[@]}" 
         
-            if [ -s ${localFastqPath}_1.fastq.gz ] && [ ! -s ${localFastqPath}_2.fastq.gz ]; then
-                mv ${localFastqPath}_1.fastq.gz ${localFastqPath}.fastq.gz
+        for basefile in "${uniq[@]}"; do
+
+            localFastqPath=${outputDir}.tmp/$basefile 
+
+            if [ ! -s "${localFastqPath}.fastq.gz" ]; then
+                # ENA has a bug: 'For some reason we dump
+                # these runs differently as we expect a CONSENSUS to be dumped.  If
+                # there is no CONSENSUS table found inside cSRA container we dump runs
+                # as-is using --split-file option.' This results in single-end FASTQ
+                # files being named <run_id>_1.fastq.gz. They say they will fix it, but
+                # in the meantime, we need to use the following workaround.
+        
+                if [ -s ${localFastqPath}_1.fastq.gz ] && [ ! -s ${localFastqPath}_2.fastq.gz ]; then
+                    mv ${localFastqPath}_1.fastq.gz ${localFastqPath}.fastq.gz
+                fi
             fi
-        fi
 
-        if [ ! -s "${localFastqPath}.fastq.gz" ]; then
-            echo "ERROR: ${localFastqPath}.fastq.gz not present: failed to retrieve $(basename ${localFastqPath}).fastq.gz"
-            exit 1
-        fi
+            if [ ! -s "${localFastqPath}.fastq.gz" ]; then
+                echo "ERROR: ${localFastqPath}.fastq.gz not present: failed to retrieve $(basename ${localFastqPath}).fastq.gz"
+                exit 1
+            fi
+        done
     fi
-
 
 
     cp -a ${outputDir}.tmp/. ${outputDir}/

--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -1187,7 +1187,7 @@ fetch_library_files_from_ena() {
     for liblist in "$libraryListing" ; do
 
             fname=$(basename $liblist )
-            
+
             if [ "$sepe" == "PAIRED" ]; then
     
                 if [[ "$fname" =~ _[0-9]".fastq.gz" ]]; then  
@@ -1288,8 +1288,8 @@ fetch_library_files_from_ena() {
         done
     fi
 
-    cp -a ${tempdir}/. ${outputDir}/
-    #rm -rf ${outputDir}.tmp
+    cp -a $tempdir/. $outputDir/
+
     echo "Retrieved $sepe-END $library from ENA successfully"
 
 }

--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -1197,6 +1197,7 @@ fetch_library_files_from_ena() {
 
         # get base filenames to be checked
         uniq=($(printf "%s\n" "${filenames_arr[@]}" | sort -u | tr '\n' ' ' ))
+        printf "%s\n" "${uniq[@]}" 
         
         for basefile in "${uniq[@]}"; do
 

--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -1230,13 +1230,14 @@ fetch_library_files_from_ena() {
                 # If we have a single file, check if interleaved fastq filesee and deinterleave it
 
                 if [ -s ${localFastqPath}.fastq.gz ]; then
-
+                    set +e
                     fastq_info ${localFastqPath}.fastq.gz pe
                     if [ $? -ne 0 ]; then
                         rm -rf ${localFastqPath}.fastq.gz
                         echo "ERROR: Failed validation of interleaved PE fastq file ${localFastqPath}.fastq.gz"
                         return 1
                     fi
+                    set -e
 
                     echo "Trying to deinterleave a FASTQ file of paired reads into two FASTQ files"
                     gzip -dc ${localFastqPath}.fastq.gz | deinterleave_fastq.sh ${localFastqPath}_1.fastq ${localFastqPath}_2.fastq
@@ -1254,6 +1255,7 @@ fetch_library_files_from_ena() {
                     fi
 
                     # Validate fastq
+                    set +e
                     fastq_info ${localFastqPath}_1.fastq ${localFastqPath}_2.fastq
                     if [ $? -ne 0 ]; then
                         rm -rf ${localFastqPath}_*.fastq
@@ -1261,6 +1263,7 @@ fetch_library_files_from_ena() {
                         echo "ERROR: Failed fastq validation after de-interleaving ${localFastqPath}_1.fastq and ${localFastqPath}_2.fastq"
                         return 1
                     fi
+                    set -e
 
                     echo "Deinterleave successful"
                     rm -rf ${localFastqPath}.fastq.gz

--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -1201,6 +1201,7 @@ fetch_library_files_from_ena() {
     if [ "$sepe" == "PAIRED" ]; then
 
         # get base filenames to be checked
+        echo "paired end"
         uniq=($(printf "%s\n" "${filenames_arr[@]}" | sort -u | tr '\n' ' ' ))
         echo "${uniq[@]}" 
         
@@ -1210,7 +1211,7 @@ fetch_library_files_from_ena() {
 
             if [ ! -s "${localFastqPath}_1.fastq.gz" ] ||  [ ! -s "${localFastqPath}_2.fastq.gz" ]; then
     
-                if [ -e "${localFastqPath}_1.fastq.gz" ]; then
+                if [ -s "${localFastqPath}_1.fastq.gz" ]; then
         
                     # Only the _1 file exists, this is a possible interleaved situation                
 
@@ -1219,7 +1220,7 @@ fetch_library_files_from_ena() {
 
                 # If we have a single file, see if we can deinterleave it
 
-                if [ -e ${localFastqPath}.fastq.gz ]; then
+                if [ -s ${localFastqPath}.fastq.gz ]; then
                     echo "Trying to deinterleave a FASTQ file of paired reads into two FASTQ files"
                     gzip -dc ${localFastqPath}.fastq.gz | deinterleave_fastq.sh ${localFastqPath}_1.fastq ${localFastqPath}_2.fastq
                     # ${IRAP_SOURCE_DIR}/scripts/deinterleave.sh $possibleInterleavedFile ${localFastqPath} 2> /dev/null

--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -1141,6 +1141,8 @@ get_library_listing() {
 
 # Fetch all available files for a given library
 
+# {relocate logic here and possibly on fetchEnaLibraryFastqs.sh}
+
 fetch_library_files_from_ena() {
     local library=$1
     local outputDir=$2

--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -1154,7 +1154,7 @@ fetch_library_files_from_ena() {
     local tempdir=$(get_temp_dir)
     check_variables 'library'
 
-    filenames_arr=()
+    local filenames_arr=()
 
     local listMethod='ftp'
     if [ "$method" == 'ssh' ]; then
@@ -1171,9 +1171,9 @@ fetch_library_files_from_ena() {
         echo -e "$libraryListing" | while read -r l; do
            local fileName=$(basename $l )
            if [ "$sepe" == "PAIRED" ]; then
-              filenames_arr+=(${fileName//_*fastq.gz/});
+              filenames_arr+=(${fileName//_*fastq.gz/})
            else
-              filenames_arr+=(${fileName//.fastq.gz/});
+              filenames_arr+=(${fileName//.fastq.gz/})
            fi
            echo "Downloading file $fileName for $library to ${tempdir}"
             if [ $method == 'auto' ]; then
@@ -1203,10 +1203,10 @@ fetch_library_files_from_ena() {
         # get base filenames to be checked
         echo "paired end"
         echo "${filenames_arr[@]}" 
-        #uniq=($(printf "%s\n" "${filenames_arr[@]}" | sort -u | tr '\n' ' ' ))
-        #echo "${uniq[@]}" 
+        uniq=($(printf "%s\n" "${filenames_arr[@]}" | sort -u | tr '\n' ' ' ))
+        echo "${uniq[@]}" 
         
-        for basefile in "${filenames_arr[@]}"; do
+        for basefile in "${uniq[@]}"; do
             
             localFastqPath=${tempdir}/$basefile 
 

--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -1202,10 +1202,11 @@ fetch_library_files_from_ena() {
 
         # get base filenames to be checked
         echo "paired end"
-        uniq=($(printf "%s\n" "${filenames_arr[@]}" | sort -u | tr '\n' ' ' ))
-        echo "${uniq[@]}" 
+        echo "${filenames_arr[@]}" 
+        #uniq=($(printf "%s\n" "${filenames_arr[@]}" | sort -u | tr '\n' ' ' ))
+        #echo "${uniq[@]}" 
         
-        for basefile in "${uniq[@]}"; do
+        for basefile in "${filenames_arr[@]}"; do
             
             localFastqPath=${tempdir}/$basefile 
 

--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -1210,22 +1210,24 @@ fetch_library_files_from_ena() {
             
                 if [ $? -ne 0 ]; then
                     rm -rf ${localFastqPath}*.fastq.gz
-                    die "ERROR: Failed to de-interleave ${localFastqPath}.fastq.gz" 9
+                    echo "ERROR: Failed to de-interleave ${localFastqPath}.fastq.gz"
+                    exit 1
                 else
                     if [ ! -s "${localFastqPath}_1.fastq" ] ||  [ ! -s "${localFastqPath}_2.fastq" ]; then
                         rm -rf ${localFastqPath}*.fastq.gz
-                        die "ERROR: Failed to de-interleave, forward or reverse not generated" 9
+                        echo "ERROR: Failed to de-interleave, forward or reverse not generated"
+                        exit 1
                     fi
                 fi
-                gzip ${localFastqPath}_1.fastq
-                gzip ${localFastqPath}_2.fastq
+                gzip ${localFastqPath}_*.fastq
             fi
             # Whether public or private, downloaded directly or created by
             # de-interleaving, we should now have both read files
 
             for readFile in ${localFastqPath}_1.fastq.gz ${localFastqPath}_2.fastq.gz; do
                 if [ ! -s $readFile ]; then
-                    die "ERROR: Failed to retrieve ${readFile}" 11
+                    echo "ERROR: Failed to retrieve ${readFile}"
+                    exit 1
                 fi
             done
         else
@@ -1246,7 +1248,8 @@ fetch_library_files_from_ena() {
         fi
 
         if [ ! -s "${localFastqPath}.fastq.gz" ]; then
-            die "ERROR: ${localFastqPath}.fastq.gz not present: failed to retrieve $(basename ${localFastqPath}).fastq.gz" 11
+            echo "ERROR: ${localFastqPath}.fastq.gz not present: failed to retrieve $(basename ${localFastqPath}).fastq.gz"
+            exit 1
         fi
     fi
 

--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -1170,7 +1170,11 @@ fetch_library_files_from_ena() {
     else
         echo -e "$libraryListing" | while read -r l; do
            local fileName=$(basename $l )
-           filenames_arr+=(${fileName//_*fastq.gz/});
+           if [ "$sepe" == "PAIRED" ]; then
+              filenames_arr+=(${fileName//_*fastq.gz/});
+           else
+              filenames_arr+=(${fileName//.fastq.gz/});
+           fi
            echo "Downloading file $fileName for $library to ${tempdir}"
             if [ $method == 'auto' ]; then
                 fetchMethod='fetch_file_from_ena_auto'

--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -1163,20 +1163,20 @@ fetch_library_files_from_ena() {
     local libraryListing=
     libraryListing=$(get_library_listing $library $listMethod $status)
     local exitCode=$?
-    echo $libraryListing
+
     if [ $exitCode -ne 0 ]; then
         return 5
     else
         echo -e "$libraryListing" | while read -r l; do
            local fileName=$(basename $l )
-           echo "Downloading file $fileName for $library to ${tempdir}"
+           echo "Downloading file $fileName for $library to $tempdir"
             if [ $method == 'auto' ]; then
                 fetchMethod='fetch_file_from_ena_auto'
             else
                 fetchMethod="fetch_file_from_ena_over_$method"
             fi
 
-            $fetchMethod $l ${tempdir}/$fileName $retries $library "" "$downloadType" $status
+            $fetchMethod $l $tempdir/$fileName $retries $library "" "$downloadType" $status
             local returnCode=$?
             if [ $returnCode -ne 0 ]; then
                 return $returnCode
@@ -1185,8 +1185,11 @@ fetch_library_files_from_ena() {
     fi
 
     for liblist in "$libraryListing" ; do
+
+            fname=$(basename $liblist )
+            
             if [ "$sepe" == "PAIRED" ]; then
-                fname=$(basename $liblist )
+    
                 if [[ "$fname" =~ _[0-9]".fastq.gz" ]]; then  
                     filenames_arr+=( "${fname//_*fastq.gz/}" )
                 else

--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -1170,8 +1170,14 @@ fetch_library_files_from_ena() {
     else
         echo -e "$libraryListing" | while read -r l; do
            local fileName=$(basename $l )
-           if [ "$sepe" == "PAIRED" ]; then
-              filenames_arr+=(${fileName//_*fastq.gz/})
+            if [ "$sepe" == "PAIRED" ]; then
+                echo $fileName
+                if [[ "$fileName" =~ _[0-9]".fastq.gz" ]]; then  
+                    filenames_arr+=(${fileName//_*fastq.gz/})
+                else
+                    echo "it could be single end"
+                    filenames_arr+=(${fileName//.fastq.gz/})
+                fi
            else
               filenames_arr+=(${fileName//.fastq.gz/})
            fi

--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -1189,7 +1189,7 @@ fetch_library_files_from_ena() {
 
     sleep 10
 
-    localFastqPath=${ISL_RAW_DIR}/$(get_library_path $library)
+    localFastqPath=${outputDir}/$library
 
     if [ "$sepe" == "PAIRED" ]; then
 

--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -1256,6 +1256,7 @@ fetch_library_files_from_ena() {
         # get base filenames to be checked
         uniq=($(printf "%s\n" "${filenames_arr[@]}" | sort -u | tr '\n' ' ' ))
         #printf "%s\n" "${uniq[@]}" 
+        echo "${uniq[@]}" 
         
         for basefile in "${uniq[@]}"; do
 

--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -1227,7 +1227,7 @@ fetch_library_files_from_ena() {
                     mv ${localFastqPath}_1.fastq.gz ${localFastqPath}.fastq.gz
                 fi
 
-                # If we have a single file, check if interleaved fastq filesee and deinterleave it
+                # If we have a single file, check if interleaved fastq file, and attempt to deinterleave it
 
                 if [ -s ${localFastqPath}.fastq.gz ]; then
                     set +e

--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -1186,7 +1186,7 @@ fetch_library_files_from_ena() {
 
     for liblist in "$libraryListing" ; do
 
-            fname=$(basename $liblist )
+            fname=$(basename "$liblist" )
 
             if [ "$sepe" == "PAIRED" ]; then
     

--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -1197,7 +1197,7 @@ fetch_library_files_from_ena() {
                 return $returnCode
             fi
             echo $filenames_arr
-            echo "filenames_array=$filenames_arr"
+            filenames_array=("${filenames_arr[@]}") 
         done 
         set -m
 

--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -1164,7 +1164,7 @@ fetch_library_files_from_ena() {
     local libraryListing=
     libraryListing=$(get_library_listing $library $listMethod $status)
     local exitCode=$?
-
+    echo $libraryListing
     if [ $exitCode -ne 0 ]; then
         return 5
     else

--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -1202,10 +1202,10 @@ fetch_library_files_from_ena() {
 
         # get base filenames to be checked
         uniq=($(printf "%s\n" "${filenames_arr[@]}" | sort -u | tr '\n' ' ' ))
-        #printf "%s\n" "${uniq[@]}" 
+        echo "${uniq[@]}" 
         
         for basefile in "${uniq[@]}"; do
-
+            
             localFastqPath=${tempdir}/$basefile 
 
             if [ ! -s "${localFastqPath}_1.fastq.gz" ] ||  [ ! -s "${localFastqPath}_2.fastq.gz" ]; then

--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -1150,7 +1150,8 @@ fetch_library_files_from_ena() {
     local downloadType=${6:-'fastq'}
     local sepe=${7:-'PAIRED'}
 
-    mkdir -p ${outputDir}.tmp
+    #mkdir -p ${outputDir}.tmp
+    local tempdir=$(get_temp_dir)
     check_variables 'library'
 
     filenames_arr=()
@@ -1170,14 +1171,14 @@ fetch_library_files_from_ena() {
         echo -e "$libraryListing" | while read -r l; do
            local fileName=$(basename $l )
            filenames_arr+=(${fileName//_*fastq.gz/});
-           echo "Downloading file $fileName for $library to ${outputDir}.tmp"
+           echo "Downloading file $fileName for $library to ${tempdir}"
             if [ $method == 'auto' ]; then
                 fetchMethod='fetch_file_from_ena_auto'
             else
                 fetchMethod="fetch_file_from_ena_over_$method"
             fi
 
-            $fetchMethod $l ${outputDir}.tmp/$fileName $retries $library "" "$downloadType" $status
+            $fetchMethod $l ${tempdir}/$fileName $retries $library "" "$downloadType" $status
             local returnCode=$?
             if [ $returnCode -ne 0 ]; then
                 return $returnCode
@@ -1201,7 +1202,7 @@ fetch_library_files_from_ena() {
         
         for basefile in "${uniq[@]}"; do
 
-            localFastqPath=${outputDir}.tmp/$basefile 
+            localFastqPath=${tempdir}/$basefile 
 
             if [ ! -s "${localFastqPath}_1.fastq.gz" ] ||  [ ! -s "${localFastqPath}_2.fastq.gz" ]; then
     
@@ -1254,7 +1255,7 @@ fetch_library_files_from_ena() {
         
         for basefile in "${uniq[@]}"; do
 
-            localFastqPath=${outputDir}.tmp/$basefile 
+            localFastqPath=${tempdir}/$basefile 
 
             if [ ! -s "${localFastqPath}.fastq.gz" ]; then
                 # ENA has a bug: 'For some reason we dump
@@ -1277,8 +1278,8 @@ fetch_library_files_from_ena() {
     fi
 
 
-    cp -a ${outputDir}.tmp/. ${outputDir}/
-    rm -rf ${outputDir}.tmp
+    cp -a ${tempdir}/. ${outputDir}/
+    #rm -rf ${outputDir}.tmp
     echo "Retrieved $sepe-END $library from ENA successfully"
 
 }

--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -1154,7 +1154,7 @@ fetch_library_files_from_ena() {
     local tempdir=$(get_temp_dir)
     check_variables 'library'
 
-    local filenames_arr=()
+    local declare -a filenames_arr
 
     local listMethod='ftp'
     if [ "$method" == 'ssh' ]; then
@@ -1173,13 +1173,13 @@ fetch_library_files_from_ena() {
             if [ "$sepe" == "PAIRED" ]; then
                 echo $fileName
                 if [[ "$fileName" =~ _[0-9]".fastq.gz" ]]; then  
-                    filenames_arr+=(${fileName//_*fastq.gz/})
+                    filenames_arr+=( "${fileName//_*fastq.gz/}" )
                 else
-                    echo "it could be single end"
-                    filenames_arr+=(${fileName//.fastq.gz/})
+                    echo "WARNING: paired-end provided, but it could actually be single end"
+                    filenames_arr+=( "${fileName//.fastq.gz/}" )
                 fi
            else
-              filenames_arr+=(${fileName//.fastq.gz/})
+              filenames_arr+=( "${fileName//.fastq.gz/}" )
            fi
            echo "Downloading file $fileName for $library to ${tempdir}"
             if [ $method == 'auto' ]; then

--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -1154,7 +1154,7 @@ fetch_library_files_from_ena() {
     local tempdir=$(get_temp_dir)
     check_variables 'library'
 
-    local filenames_array=()
+    local filenames_arr=()
 
     local listMethod='ftp'
     if [ "$method" == 'ssh' ]; then
@@ -1184,7 +1184,7 @@ fetch_library_files_from_ena() {
             fi
         done 
     fi
-    for liblist in $libraryListing; do
+    for liblist in "$libraryListing" ; do
             if [ "$sepe" == "PAIRED" ]; then
                 fname=$(basename $liblist )
                 if [[ "$fname" =~ _[0-9]".fastq.gz" ]]; then  
@@ -1193,13 +1193,13 @@ fetch_library_files_from_ena() {
                     echo "WARNING: paired-end provided, but it could actually be single end"
                     filenames_arr+=( "${fname//.fastq.gz/}" )
                 fi
-           else
-              filenames_arr+=( "${fname//.fastq.gz/}" )
-           fi
+            else
+                filenames_arr+=( "${fname//.fastq.gz/}" )
+            fi
     done
     # get base filenames to be checked
-    echo "${filenames_array[@]}" 
-    uniq=($(printf "%s\n" "${filenames_array[@]}" | sort -u | tr '\n' ' ' ))
+    echo "${filenames_arr[@]}" 
+    uniq=($(printf "%s\n" "${filenames_arr[@]}" | sort -u | tr '\n' ' ' ))
     echo "${uniq[@]}" 
     # A sleep here to try to deal with cases where we get a success exit code
     # above, but the file does not exist when checked below. Suspect some sort of

--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -1243,27 +1243,29 @@ fetch_library_files_from_ena() {
             else
                 echo "Read files already present"
             fi
-        else
-            if [ ! -s "${localFastqPath}.fastq.gz" ]; then
-                # ENA has a bug: 'For some reason we dump
-                # these runs differently as we expect a CONSENSUS to be dumped.  If
-                # there is no CONSENSUS table found inside cSRA container we dump runs
-                # as-is using --split-file option.' This results in single-end FASTQ
-                # files being named <run_id>_1.fastq.gz. They say they will fix it, but
-                # in the meantime, we need to use the following workaround.
-        
-                if [ -s ${localFastqPath}_1.fastq.gz ] && [ ! -s ${localFastqPath}_2.fastq.gz ]; then
-                    mv ${localFastqPath}_1.fastq.gz ${localFastqPath}.fastq.gz
-                fi
-            fi
+        done
 
-            if [ ! -s "${localFastqPath}.fastq.gz" ]; then
-                echo "ERROR: ${localFastqPath}.fastq.gz not present: failed to retrieve $(basename ${localFastqPath}).fastq.gz"
-                exit 1
+    else
+        if [ ! -s "${localFastqPath}.fastq.gz" ]; then
+            # ENA has a bug: 'For some reason we dump
+            # these runs differently as we expect a CONSENSUS to be dumped.  If
+            # there is no CONSENSUS table found inside cSRA container we dump runs
+            # as-is using --split-file option.' This results in single-end FASTQ
+            # files being named <run_id>_1.fastq.gz. They say they will fix it, but
+            # in the meantime, we need to use the following workaround.
+        
+            if [ -s ${localFastqPath}_1.fastq.gz ] && [ ! -s ${localFastqPath}_2.fastq.gz ]; then
+                mv ${localFastqPath}_1.fastq.gz ${localFastqPath}.fastq.gz
             fi
         fi
 
-    done
+        if [ ! -s "${localFastqPath}.fastq.gz" ]; then
+            echo "ERROR: ${localFastqPath}.fastq.gz not present: failed to retrieve $(basename ${localFastqPath}).fastq.gz"
+            exit 1
+        fi
+    fi
+
+
 
     cp -a ${outputDir}.tmp/. ${outputDir}/
     rm -rf ${outputDir}.tmp

--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -1215,6 +1215,7 @@ fetch_library_files_from_ena() {
                 # If we have a single file, see if we can deinterleave it
 
                 if [ -e ${localFastqPath}.fastq.gz ]; then
+                    echo "Trying to deinterleave a FASTQ file of paired reads into two FASTQ files"
                     gzip -dc ${localFastqPath}.fastq.gz | deinterleave_fastq.sh ${localFastqPath}_1.fastq ${localFastqPath}_2.fastq
                     # ${IRAP_SOURCE_DIR}/scripts/deinterleave.sh $possibleInterleavedFile ${localFastqPath} 2> /dev/null
             
@@ -1246,6 +1247,7 @@ fetch_library_files_from_ena() {
         done
 
     else
+        echo "single end"
         if [ ! -s "${localFastqPath}.fastq.gz" ]; then
             # ENA has a bug: 'For some reason we dump
             # these runs differently as we expect a CONSENSUS to be dumped.  If

--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -1154,7 +1154,7 @@ fetch_library_files_from_ena() {
     local tempdir=$(get_temp_dir)
     check_variables 'library'
 
-    local declare -a filenames_arr
+    local filenames_array=()
 
     local listMethod='ftp'
     if [ "$method" == 'ssh' ]; then
@@ -1168,7 +1168,10 @@ fetch_library_files_from_ena() {
     if [ $exitCode -ne 0 ]; then
         return 5
     else
+        set +m # To disable job control
         echo -e "$libraryListing" | while read -r l; do
+           shopt -s lastpipe
+           local filenames_arr=()
            local fileName=$(basename $l )
             if [ "$sepe" == "PAIRED" ]; then
                 echo $fileName
@@ -1193,7 +1196,10 @@ fetch_library_files_from_ena() {
             if [ $returnCode -ne 0 ]; then
                 return $returnCode
             fi
+            echo $filenames_arr
+            echo "filenames_array=$filenames_arr"
         done 
+        set -m
 
     fi
 
@@ -1208,8 +1214,8 @@ fetch_library_files_from_ena() {
 
         # get base filenames to be checked
         echo "paired end"
-        echo "${filenames_arr[@]}" 
-        uniq=($(printf "%s\n" "${filenames_arr[@]}" | sort -u | tr '\n' ' ' ))
+        echo "${filenames_array[@]}" 
+        uniq=($(printf "%s\n" "${filenames_array[@]}" | sort -u | tr '\n' ' ' ))
         echo "${uniq[@]}" 
         
         for basefile in "${uniq[@]}"; do
@@ -1262,7 +1268,7 @@ fetch_library_files_from_ena() {
     else
         echo "single end"
         # get base filenames to be checked
-        uniq=($(printf "%s\n" "${filenames_arr[@]}" | sort -u | tr '\n' ' ' ))
+        uniq=($(printf "%s\n" "${filenames_array[@]}" | sort -u | tr '\n' ' ' ))
         #printf "%s\n" "${uniq[@]}" 
         echo "${uniq[@]}" 
         

--- a/atlas-fastq-provider-functions.sh
+++ b/atlas-fastq-provider-functions.sh
@@ -1234,8 +1234,8 @@ fetch_library_files_from_ena() {
                     fastq_info ${localFastqPath}.fastq.gz pe
                     if [ $? -ne 0 ]; then
                         rm -rf ${localFastqPath}.fastq.gz
-                        echo "ERROR: Failed  validation of interleaved fastq file ${localFastqPath}.fastq.gz"
-                        exit 1
+                        echo "ERROR: Failed validation of interleaved PE fastq file ${localFastqPath}.fastq.gz"
+                        return 1
                     fi
 
                     echo "Trying to deinterleave a FASTQ file of paired reads into two FASTQ files"
@@ -1244,12 +1244,12 @@ fetch_library_files_from_ena() {
                     if [ $? -ne 0 ]; then
                         rm -rf ${localFastqPath}*.fastq*
                         echo "ERROR: Failed to de-interleave ${localFastqPath}.fastq.gz"
-                        exit 1
+                        return 1
                     else
                         if [ ! -s "${localFastqPath}_1.fastq" ] ||  [ ! -s "${localFastqPath}_2.fastq" ]; then
                             rm -rf ${localFastqPath}*.fastq*
                             echo "ERROR: Failed to de-interleave, forward or reverse not generated"
-                            exit 1
+                            return 1
                         fi
                     fi
 
@@ -1259,7 +1259,7 @@ fetch_library_files_from_ena() {
                         rm -rf ${localFastqPath}_*.fastq
                         rm -rf ${localFastqPath}.fastq.gz
                         echo "ERROR: Failed fastq validation after de-interleaving ${localFastqPath}_1.fastq and ${localFastqPath}_2.fastq"
-                        exit 1
+                        return 1
                     fi
 
                     echo "Deinterleave successful"
@@ -1272,7 +1272,7 @@ fetch_library_files_from_ena() {
                 for readFile in ${localFastqPath}_1.fastq.gz ${localFastqPath}_2.fastq.gz; do
                     if [ ! -s $readFile ]; then
                         echo "ERROR: Failed to retrieve ${readFile}"
-                        exit 1
+                        return 1
                     fi
                 done
             else
@@ -1302,7 +1302,7 @@ fetch_library_files_from_ena() {
 
             if [ ! -s "${localFastqPath}.fastq.gz" ]; then
                 echo "ERROR: ${localFastqPath}.fastq.gz not present: failed to retrieve $(basename ${localFastqPath}).fastq.gz"
-                exit 1
+                return 1
             fi
         done
     fi

--- a/atlas-fastq-provider-post-install-tests.sh
+++ b/atlas-fastq-provider-post-install-tests.sh
@@ -10,14 +10,15 @@ setup() {
     fastq_file_http="${output_dir}/ERR1888172_1.http.fastq.gz"
     sra="sra/ftp://ftp.sra.ebi.ac.uk/vol1/srr/SRR100/060/SRR10069860/SRR10069860_1.fastq.gz"
     sra_lib="SRR10069860"
-    sra_lib_se="SRR19538252"
-    sra_file_lib_ftp_se="${output_dir}/SRR19538252_1.fastq.gz"
     sra_file_ftp="${output_dir}/SRR10069860_1.sra.ftp.fastq.gz"
     sra_file_http="${output_dir}/SRR10069860_1.sra.http.fastq.gz"
     sra_file_lib_ftp="${output_dir}/SRR10069860_1.fastq.gz"
     non_ena_sra="sra/https://sra-download.ncbi.nlm.nih.gov/traces/sra43/SRR/010931/SRR11194113/SRR11194113_3.fastq.gz"
     non_ena_sra_file="${output_dir}/SRR11194113_3.fastq.gz"
     export NOPROBE=1
+
+    ena_lib_se="ERR2163350"
+    fastq_file_ftp_se="${output_dir}/ERR2163350_1.ftp.fastq.gz"
 
     if [ ! -d "$data_dir" ]; then
         mkdir -p $data_dir
@@ -37,6 +38,17 @@ setup() {
 
     [ "$status" -eq 0 ]
     [ -f "$fastq_file_ftp" ]
+}
+
+@test "Download all files from an ENA library as PAIRED-end, providing a SINGLE-end library" {
+    if  [ "$resume" = 'true' ] && [ -f "$fastq_file_ftp_se" ]; then
+        skip "$fastq_file_ftp_se exists"
+    fi
+
+    run rm -rf $fastq_file_ftp_se && eval "fetchEnaLibraryFastqs.sh -l ${ena_lib_se} -d ${output_dir} -t fastq -n PAIRED"
+
+    [ "$status" -eq 0 ]
+    [ -f "$fastq_file_ftp_se" ]
 }
 
 @test "Download and unpack SRA file from FTP, providing prefixed link" {
@@ -72,16 +84,6 @@ setup() {
     [ -f "$sra_file_lib_ftp" ]
 }
 
-@test "Download and unpack SRA file from FTP as PAIRED-end, providing just a SINGLE-end library identifier" {
-    if  [ "$resume" = 'true' ] && [ -f "$sra_file_lib_ftp_se" ]; then
-        skip "$sra_file_lib_ftp_se exists"
-    fi
-
-    run rm -rf $sra_file_lib_ftp_se && eval "fetchEnaLibraryFastqs.sh -l ${sra_lib_se} -d ${output_dir} -m ftp -t srr -n PAIRED"
-
-    [ "$status" -eq 0 ]
-    [ -f "$sra_file_lib_ftp_se" ]
-}
 
 #@test "Download Fastq file from HTTP" {
 #    if  [ "$resume" = 'true' ] && [ -f "$fastq_file_http" ]; then

--- a/atlas-fastq-provider-post-install-tests.sh
+++ b/atlas-fastq-provider-post-install-tests.sh
@@ -110,14 +110,14 @@ setup() {
     [ -f "$fastq_file_ftp_se" ]
 }
 
-@test "Download and unpack SRA file as PE, providing just a SE library identifier (success deinterleave process)" {
+@test "Download and unpack SRA file as PE, providing just a SE library identifier (fail deinterleave process)" {
     if  [ "$resume" = 'true' ] && [ -f "$fastq_file_ftp_se_1" ] && [ -f "$fastq_file_ftp_se_2" ]; then
         skip "$fastq_file_ftp_se_1 and $fastq_file_ftp_se_2 exist"
     fi
 
     run rm -rf $fastq_file_ftp_se_1 && run rm -rf $fastq_file_ftp_se_2 && eval "fetchEnaLibraryFastqs.sh -l ${ena_lib_se} -d ${output_dir} -m ftp -t fastq -n PAIRED"
 
-    [ "$status" -eq 0 ]
-    [  -f "$fastq_file_ftp_se_1" ]
-    [  -f "$fastq_file_ftp_se_2" ]
+    [ "$status" -eq 1 ]
+    [  ! -f "$fastq_file_ftp_se_1" ]
+    [  ! -f "$fastq_file_ftp_se_2" ]
 }

--- a/atlas-fastq-provider-post-install-tests.sh
+++ b/atlas-fastq-provider-post-install-tests.sh
@@ -17,8 +17,8 @@ setup() {
     non_ena_sra_file="${output_dir}/SRR11194113_3.fastq.gz"
     export NOPROBE=1
 
-    ena_lib_se="CG2-Bacteria"
-    fastq_file_ftp_se="${output_dir}/SRR11267275.fastq.gz"
+    ena_lib_se="SRR18315788"
+    fastq_file_ftp_se="${output_dir}/SRR18315788.fastq.gz"
 
     if [ ! -d "$data_dir" ]; then
         mkdir -p $data_dir
@@ -47,8 +47,8 @@ setup() {
 
     run rm -rf $fastq_file_ftp_se && eval "fetchEnaLibraryFastqs.sh -l ${ena_lib_se} -d ${output_dir} -t fastq -n PAIRED"
 
-    [ "$status" -eq 0 ]
-    [ -f "$fastq_file_ftp_se" ]
+    [ "$status" -eq 1 ]
+    #[ -f "$fastq_file_ftp_se" ]
 }
 
 @test "Download and unpack SRA file from FTP, providing prefixed link" {

--- a/atlas-fastq-provider-post-install-tests.sh
+++ b/atlas-fastq-provider-post-install-tests.sh
@@ -19,6 +19,8 @@ setup() {
 
     ena_lib_se="SRR18315788"
     fastq_file_ftp_se="${output_dir}/SRR18315788.fastq.gz"
+    fastq_file_ftp_se_1="${output_dir}/SRR18315788_1.fastq.gz"
+    fastq_file_ftp_se_2="${output_dir}/SRR18315788_2.fastq.gz"
 
     if [ ! -d "$data_dir" ]; then
         mkdir -p $data_dir
@@ -97,7 +99,7 @@ setup() {
 #    [ -f "$sra_file_http" ]
 #}
 
-@test "Download and unpack SRA file as SE, providing just a SE library identifier" {
+@test "Download and unpack SRA file as SE, providing just a SE library identifier (no deinterleave)" {
     if  [ "$resume" = 'true' ] && [ -f "$fastq_file_ftp_se" ]; then
         skip "$fastq_file_ftp_se exists"
     fi
@@ -108,14 +110,14 @@ setup() {
     [ -f "$fastq_file_ftp_se" ]
 }
 
-@test "Download and unpack SRA file as PE, providing just a SE library identifier" {
-    if  [ "$resume" = 'true' ] && [ -f "$fastq_file_ftp_se" ]; then
-        skip "$fastq_file_ftp_se exists"
+@test "Download and unpack SRA file as PE, providing just a SE library identifier (success deinterleave process)" {
+    if  [ "$resume" = 'true' ] && [ -f "$fastq_file_ftp_se_1" ] && [ -f "$fastq_file_ftp_se_2" ]; then
+        skip "$fastq_file_ftp_se_1 and $fastq_file_ftp_se_2 exist"
     fi
 
-    run rm -rf $fastq_file_ftp_se && eval "fetchEnaLibraryFastqs.sh -l ${ena_lib_se} -d ${output_dir} -m ftp -t fastq -n PAIRED"
+    run rm -rf $fastq_file_ftp_se_1 && run rm -rf $fastq_file_ftp_se_2 && eval "fetchEnaLibraryFastqs.sh -l ${sra_lib} -d ${output_dir} -m ftp -t fastq -n PAIRED"
 
-    [ "$status" -eq 1 ]
-    [ ! -f "$fastq_file_ftp_se" ]
+    [ "$status" -eq 0 ]
+    [ ! -f "$fastq_file_ftp_se_1" ]
+    [ ! -f "$fastq_file_ftp_se_2" ]
 }
-

--- a/atlas-fastq-provider-post-install-tests.sh
+++ b/atlas-fastq-provider-post-install-tests.sh
@@ -115,7 +115,7 @@ setup() {
         skip "$fastq_file_ftp_se_1 and $fastq_file_ftp_se_2 exist"
     fi
 
-    run rm -rf $fastq_file_ftp_se_1 && run rm -rf $fastq_file_ftp_se_2 && eval "fetchEnaLibraryFastqs.sh -l ${sra_lib} -d ${output_dir} -m ftp -t fastq -n PAIRED"
+    run rm -rf $fastq_file_ftp_se_1 && run rm -rf $fastq_file_ftp_se_2 && eval "fetchEnaLibraryFastqs.sh -l ${ena_lib_se} -d ${output_dir} -m ftp -t fastq -n PAIRED"
 
     [ "$status" -eq 0 ]
     [  -f "$fastq_file_ftp_se_1" ]

--- a/atlas-fastq-provider-post-install-tests.sh
+++ b/atlas-fastq-provider-post-install-tests.sh
@@ -97,6 +97,17 @@ setup() {
 #    [ -f "$sra_file_http" ]
 #}
 
+@test "Download all files from an ENA library as SINGLE-end, providing a SINGLE-end library" {
+    if  [ "$resume" = 'true' ] && [ -f "$fastq_file_ftp_se" ]; then
+        skip "$fastq_file_ftp_se exists"
+    fi
+
+    run rm -rf $fastq_file_ftp_se && eval "fetchEnaLibraryFastqs.sh -l ${ena_lib_se} -d ${output_dir} -m ftp -t srr -n SINGLE"
+
+    [ "$status" -eq 0 ]
+    [ -f "$fastq_file_ftp_se" ]
+}
+
 @test "Download all files from an ENA library as PAIRED-end, providing a SINGLE-end library" {
     if  [ "$resume" = 'true' ] && [ -f "$fastq_file_ftp_se" ]; then
         skip "$fastq_file_ftp_se exists"
@@ -105,5 +116,6 @@ setup() {
     run rm -rf $fastq_file_ftp_se && eval "fetchEnaLibraryFastqs.sh -l ${ena_lib_se} -d ${output_dir} -m ftp -t srr -n PAIRED"
 
     [ "$status" -eq 0 ]
-    [ -f "$fastq_file_ftp_se" ]
+    #[ -f "$fastq_file_ftp_se" ]
 }
+

--- a/atlas-fastq-provider-post-install-tests.sh
+++ b/atlas-fastq-provider-post-install-tests.sh
@@ -102,7 +102,7 @@ setup() {
         skip "$fastq_file_ftp_se exists"
     fi
 
-    run rm -rf $fastq_file_ftp_se && eval "fetchEnaLibraryFastqs.sh -l ${ena_lib_se} -d ${output_dir} -m ftp -t fastq -n SINGLE"
+    run rm -rf $fastq_file_ftp_se && eval "fetchEnaLibraryFastqs.sh -l ${ena_lib_se} -d ${output_dir}  -t fastq -n SINGLE"
 
     [ "$status" -eq 0 ]
     [ -f "$fastq_file_ftp_se" ]
@@ -113,9 +113,9 @@ setup() {
         skip "$fastq_file_ftp_se exists"
     fi
 
-    run rm -rf $fastq_file_ftp_se && eval "fetchEnaLibraryFastqs.sh -l ${ena_lib_se} -d ${output_dir} -m ftp -t fastq -n PAIRED"
+    run rm -rf $fastq_file_ftp_se && eval "fetchEnaLibraryFastqs.sh -l ${ena_lib_se} -d ${output_dir} -t fastq -n PAIRED"
 
     [ "$status" -eq 1 ]
-    [ ! -f "$fastq_file_ftp_se" ]
+    #[ ! -f "$fastq_file_ftp_se" ]
 }
 

--- a/atlas-fastq-provider-post-install-tests.sh
+++ b/atlas-fastq-provider-post-install-tests.sh
@@ -104,6 +104,6 @@ setup() {
 
     run rm -rf $fastq_file_ftp_se && eval "fetchEnaLibraryFastqs.sh -l ${ena_lib_se} -d ${output_dir} -m ftp -t srr -n PAIRED"
 
-    [ "$status" -eq 1 ]
+    [ "$status" -eq 0 ]
     [ -f "$fastq_file_ftp_se" ]
 }

--- a/atlas-fastq-provider-post-install-tests.sh
+++ b/atlas-fastq-provider-post-install-tests.sh
@@ -17,8 +17,8 @@ setup() {
     non_ena_sra_file="${output_dir}/SRR11194113_3.fastq.gz"
     export NOPROBE=1
 
-    ena_lib_se="SRR18315788"
-    fastq_file_ftp_se="${output_dir}/SRR18315788.fastq.gz"
+    ena_lib_se="SRR10069860"
+    fastq_file_ftp_se="${output_dir}/SRR10069860.fastq.gz"
 
     if [ ! -d "$data_dir" ]; then
         mkdir -p $data_dir

--- a/atlas-fastq-provider-post-install-tests.sh
+++ b/atlas-fastq-provider-post-install-tests.sh
@@ -118,6 +118,6 @@ setup() {
     run rm -rf $fastq_file_ftp_se_1 && run rm -rf $fastq_file_ftp_se_2 && eval "fetchEnaLibraryFastqs.sh -l ${sra_lib} -d ${output_dir} -m ftp -t fastq -n PAIRED"
 
     [ "$status" -eq 0 ]
-    [ ! -f "$fastq_file_ftp_se_1" ]
-    [ ! -f "$fastq_file_ftp_se_2" ]
+    [  -f "$fastq_file_ftp_se_1" ]
+    [  -f "$fastq_file_ftp_se_2" ]
 }

--- a/atlas-fastq-provider-post-install-tests.sh
+++ b/atlas-fastq-provider-post-install-tests.sh
@@ -40,17 +40,6 @@ setup() {
     [ -f "$fastq_file_ftp" ]
 }
 
-@test "Download all files from an ENA library as PAIRED-end, providing a SINGLE-end library" {
-    if  [ "$resume" = 'true' ] && [ -f "$fastq_file_ftp_se" ]; then
-        skip "$fastq_file_ftp_se exists"
-    fi
-
-    run rm -rf $fastq_file_ftp_se && eval "fetchEnaLibraryFastqs.sh -l ${ena_lib_se} -d ${output_dir} -t fastq -n PAIRED"
-
-    [ "$status" -eq 1 ]
-    #[ -f "$fastq_file_ftp_se" ]
-}
-
 @test "Download and unpack SRA file from FTP, providing prefixed link" {
     if  [ "$resume" = 'true' ] && [ -f "$sra_file_ftp" ]; then
         skip "$sra_file_ftp exists"
@@ -107,3 +96,14 @@ setup() {
 #    [ "$status" -eq 0 ]
 #    [ -f "$sra_file_http" ]
 #}
+
+@test "Download all files from an ENA library as PAIRED-end, providing a SINGLE-end library" {
+    if  [ "$resume" = 'true' ] && [ -f "$fastq_file_ftp_se" ]; then
+        skip "$fastq_file_ftp_se exists"
+    fi
+
+    run rm -rf $fastq_file_ftp_se && eval "fetchEnaLibraryFastqs.sh -l ${ena_lib_se} -d ${output_dir} -m ftp -t srr -n PAIRED"
+
+    [ "$status" -eq 1 ]
+    [ -f "$fastq_file_ftp_se" ]
+}

--- a/atlas-fastq-provider-post-install-tests.sh
+++ b/atlas-fastq-provider-post-install-tests.sh
@@ -21,6 +21,9 @@ setup() {
     fastq_file_ftp_se="${output_dir}/SRR18315788.fastq.gz"
     fastq_file_ftp_se_1="${output_dir}/SRR18315788_1.fastq.gz"
     fastq_file_ftp_se_2="${output_dir}/SRR18315788_2.fastq.gz"
+    ena_lib_pe="SRR15832741"
+    fastq_file_ftp_pe_1="${output_dir}/SRR15832741_1.fastq.gz"
+    fastq_file_ftp_pe_2="${output_dir}/SRR15832741_2.fastq.gz"
 
     if [ ! -d "$data_dir" ]; then
         mkdir -p $data_dir
@@ -99,7 +102,7 @@ setup() {
 #    [ -f "$sra_file_http" ]
 #}
 
-@test "Download and unpack SRA file as SE, providing just a SE library identifier (no deinterleave)" {
+@test "Download and unpack SRA file as SE, providing just a SE library identifier (no deinterleave attempt)" {
     if  [ "$resume" = 'true' ] && [ -f "$fastq_file_ftp_se" ]; then
         skip "$fastq_file_ftp_se exists"
     fi
@@ -110,7 +113,7 @@ setup() {
     [ -f "$fastq_file_ftp_se" ]
 }
 
-@test "Download and unpack SRA file as PE, providing just a SE library identifier (fail deinterleave process)" {
+@test "Download and unpack SRA file as PE, providing just a SE library identifier (failed deinterleave attempt)" {
     if  [ "$resume" = 'true' ] && [ -f "$fastq_file_ftp_se_1" ] && [ -f "$fastq_file_ftp_se_2" ]; then
         skip "$fastq_file_ftp_se_1 and $fastq_file_ftp_se_2 exist"
     fi
@@ -120,4 +123,16 @@ setup() {
     [ "$status" -eq 1 ]
     [  ! -f "$fastq_file_ftp_se_1" ]
     [  ! -f "$fastq_file_ftp_se_2" ]
+}
+
+@test "Download and unpack SRA file as PE, providing just a PE library identifier" {
+    if  [ "$resume" = 'true' ] && [ -f "$fastq_file_ftp_pe_1" ] && [ -f "$fastq_file_ftp_pe_2" ]; then
+        skip "$fastq_file_ftp_pe_1 and $fastq_file_ftp_pe_2 exist"
+    fi
+
+    run rm -rf $fastq_file_ftp_pe_1 && run rm -rf $fastq_file_ftp_pe_2 && run fetchEnaLibraryFastqs.sh -l ${ena_lib_pe} -d ${output_dir} -m ftp -t fastq -n PAIRED
+
+    [ "$status" -eq 0 ]
+    [  -f "$fastq_file_ftp_pe_1" ]
+    [  -f "$fastq_file_ftp_pe_2" ]
 }

--- a/atlas-fastq-provider-post-install-tests.sh
+++ b/atlas-fastq-provider-post-install-tests.sh
@@ -17,8 +17,8 @@ setup() {
     non_ena_sra_file="${output_dir}/SRR11194113_3.fastq.gz"
     export NOPROBE=1
 
-    ena_lib_se="SRR10069860"
-    fastq_file_ftp_se="${output_dir}/SRR10069860.fastq.gz"
+    ena_lib_se="SRR18315788"
+    fastq_file_ftp_se="${output_dir}/SRR18315788.fastq.gz"
 
     if [ ! -d "$data_dir" ]; then
         mkdir -p $data_dir
@@ -102,7 +102,7 @@ setup() {
         skip "$fastq_file_ftp_se exists"
     fi
 
-    run rm -rf $fastq_file_ftp_se && eval "fetchEnaLibraryFastqs.sh -l ${ena_lib_se} -d ${output_dir}  -t fastq -n SINGLE"
+    run rm -rf $fastq_file_ftp_se && eval "fetchEnaLibraryFastqs.sh -l ${ena_lib_se} -d ${output_dir}  -m ftp -t fastq -n SINGLE"
 
     [ "$status" -eq 0 ]
     [ -f "$fastq_file_ftp_se" ]
@@ -113,9 +113,9 @@ setup() {
         skip "$fastq_file_ftp_se exists"
     fi
 
-    run rm -rf $fastq_file_ftp_se && eval "fetchEnaLibraryFastqs.sh -l ${ena_lib_se} -d ${output_dir} -t fastq -n PAIRED"
+    run rm -rf $fastq_file_ftp_se && eval "fetchEnaLibraryFastqs.sh -l ${ena_lib_se} -d ${output_dir} -m ftp -t fastq -n PAIRED"
 
     [ "$status" -eq 1 ]
-    #[ ! -f "$fastq_file_ftp_se" ]
+    [ ! -f "$fastq_file_ftp_se" ]
 }
 

--- a/atlas-fastq-provider-post-install-tests.sh
+++ b/atlas-fastq-provider-post-install-tests.sh
@@ -17,8 +17,8 @@ setup() {
     non_ena_sra_file="${output_dir}/SRR11194113_3.fastq.gz"
     export NOPROBE=1
 
-    ena_lib_se="ERR2163350"
-    fastq_file_ftp_se="${output_dir}/ERR2163350_1.ftp.fastq.gz"
+    ena_lib_se="CG2-Bacteria"
+    fastq_file_ftp_se="${output_dir}/SRR11267275.fastq.gz"
 
     if [ ! -d "$data_dir" ]; then
         mkdir -p $data_dir

--- a/atlas-fastq-provider-post-install-tests.sh
+++ b/atlas-fastq-provider-post-install-tests.sh
@@ -115,7 +115,7 @@ setup() {
         skip "$fastq_file_ftp_se_1 and $fastq_file_ftp_se_2 exist"
     fi
 
-    run rm -rf $fastq_file_ftp_se_1 && run rm -rf $fastq_file_ftp_se_2 && eval "fetchEnaLibraryFastqs.sh -l ${ena_lib_se} -d ${output_dir} -m ftp -t fastq -n PAIRED"
+    run rm -rf $fastq_file_ftp_se_1 && run rm -rf $fastq_file_ftp_se_2 && run fetchEnaLibraryFastqs.sh -l ${ena_lib_se} -d ${output_dir} -m ftp -t fastq -n PAIRED
 
     [ "$status" -eq 1 ]
     [  ! -f "$fastq_file_ftp_se_1" ]

--- a/atlas-fastq-provider-post-install-tests.sh
+++ b/atlas-fastq-provider-post-install-tests.sh
@@ -97,25 +97,25 @@ setup() {
 #    [ -f "$sra_file_http" ]
 #}
 
-@test "Download all files from an ENA library as SINGLE-end, providing a SINGLE-end library" {
+@test "Download and unpack SRA file as SE, providing just a SE library identifier" {
     if  [ "$resume" = 'true' ] && [ -f "$fastq_file_ftp_se" ]; then
         skip "$fastq_file_ftp_se exists"
     fi
 
-    run rm -rf $fastq_file_ftp_se && eval "fetchEnaLibraryFastqs.sh -l ${ena_lib_se} -d ${output_dir} -m ftp -t srr -n SINGLE"
+    run rm -rf $fastq_file_ftp_se && eval "fetchEnaLibraryFastqs.sh -l ${ena_lib_se} -d ${output_dir} -m ftp -t fastq -n SINGLE"
 
     [ "$status" -eq 0 ]
     [ -f "$fastq_file_ftp_se" ]
 }
 
-@test "Download all files from an ENA library as PAIRED-end, providing a SINGLE-end library" {
+@test "Download and unpack SRA file as PE, providing just a SE library identifier" {
     if  [ "$resume" = 'true' ] && [ -f "$fastq_file_ftp_se" ]; then
         skip "$fastq_file_ftp_se exists"
     fi
 
-    run rm -rf $fastq_file_ftp_se && eval "fetchEnaLibraryFastqs.sh -l ${ena_lib_se} -d ${output_dir} -m ftp -t srr -n PAIRED"
+    run rm -rf $fastq_file_ftp_se && eval "fetchEnaLibraryFastqs.sh -l ${ena_lib_se} -d ${output_dir} -m ftp -t fastq -n PAIRED"
 
-    [ "$status" -eq 0 ]
-    #[ -f "$fastq_file_ftp_se" ]
+    [ "$status" -eq 1 ]
+    [ ! -f "$fastq_file_ftp_se" ]
 }
 

--- a/atlas-fastq-provider-post-install-tests.sh
+++ b/atlas-fastq-provider-post-install-tests.sh
@@ -10,12 +10,14 @@ setup() {
     fastq_file_http="${output_dir}/ERR1888172_1.http.fastq.gz"
     sra="sra/ftp://ftp.sra.ebi.ac.uk/vol1/srr/SRR100/060/SRR10069860/SRR10069860_1.fastq.gz"
     sra_lib="SRR10069860"
+    sra_lib_se="SRR19538252"
+    sra_file_lib_ftp_se="${output_dir}/SRR19538252_1.fastq.gz"
     sra_file_ftp="${output_dir}/SRR10069860_1.sra.ftp.fastq.gz"
     sra_file_http="${output_dir}/SRR10069860_1.sra.http.fastq.gz"
     sra_file_lib_ftp="${output_dir}/SRR10069860_1.fastq.gz"
     non_ena_sra="sra/https://sra-download.ncbi.nlm.nih.gov/traces/sra43/SRR/010931/SRR11194113/SRR11194113_3.fastq.gz"
     non_ena_sra_file="${output_dir}/SRR11194113_3.fastq.gz"
-    export NOPROBE=1    
+    export NOPROBE=1
 
     if [ ! -d "$data_dir" ]; then
         mkdir -p $data_dir
@@ -68,6 +70,17 @@ setup() {
 
     [ "$status" -eq 0 ]
     [ -f "$sra_file_lib_ftp" ]
+}
+
+@test "Download and unpack SRA file from FTP as PAIRED-end, providing just a SINGLE-end library identifier" {
+    if  [ "$resume" = 'true' ] && [ -f "$sra_file_lib_ftp_se" ]; then
+        skip "$sra_file_lib_ftp_se exists"
+    fi
+
+    run rm -rf $sra_file_lib_ftp_se && eval "fetchEnaLibraryFastqs.sh -l ${sra_lib_se} -d ${output_dir} -m ftp -t srr -n PAIRED"
+
+    [ "$status" -eq 0 ]
+    [ -f "$sra_file_lib_ftp_se" ]
 }
 
 #@test "Download Fastq file from HTTP" {

--- a/deinterleave_fastq.sh
+++ b/deinterleave_fastq.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Usage: deinterleave_fastq.sh < interleaved.fastq f.fastq r.fastq [compress]
+# 
+# Deinterleaves a FASTQ file of paired reads into two FASTQ
+# files specified on the command line. Optionally GZip compresses the output
+# FASTQ files using pigz if the 3rd command line argument is the word "compress"
+# 
+# Can deinterleave 100 million paired reads (200 million total
+# reads; a 43Gbyte file), in memory (/dev/shm), in 4m15s (255s)
+# 
+# Latest code: https://gist.github.com/3521724
+# Also see my interleaving script: https://gist.github.com/4544979
+# 
+# Inspired by Torsten Seemann's blog post:
+# http://thegenomefactory.blogspot.com.au/2012/05/cool-use-of-unix-paste-with-ngs.html
+
+# Set up some defaults
+GZIP_OUTPUT=0
+PIGZ_COMPRESSION_THREADS=10
+
+# If the third argument is the word "compress" then we'll compress the output using pigz
+if [[ $3 == "compress" ]]; then
+  GZIP_OUTPUT=1
+fi
+
+if [[ ${GZIP_OUTPUT} == 0 ]]; then
+  paste - - - - - - - -  | tee >(cut -f 1-4 | tr "\t" "\n" > $1) | cut -f 5-8 | tr "\t" "\n" > $2
+else
+  paste - - - - - - - -  | tee >(cut -f 1-4 | tr "\t" "\n" | pigz --best --processes ${PIGZ_COMPRESSION_THREADS} > $1) | cut -f 5-8 | tr "\t" "\n" | pigz --best --processes ${PIGZ_COMPRESSION_THREADS} > $2
+fi

--- a/deinterleave_fastq.sh
+++ b/deinterleave_fastq.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash 
+
 # Usage: deinterleave_fastq.sh < interleaved.fastq f.fastq r.fastq [compress]
 # 
 # Deinterleaves a FASTQ file of paired reads into two FASTQ

--- a/fetchEnaLibraryFastqs.sh
+++ b/fetchEnaLibraryFastqs.sh
@@ -76,7 +76,7 @@ if [ "$method" == 'dir' ]; then
 elif [ "$downloadType" == 'srr' ]; then
     fetch_library_files_from_sra_file $library $outputDir $ENA_RETRIES $method $status
 else
-    fetch_library_files_from_ena $library $outputDir $ENA_RETRIES $method $status $sepe
+    fetch_library_files_from_ena $library $outputDir $ENA_RETRIES $method $status $downloadType $sepe
 fi
 
 fetchStatus=$?

--- a/fetchEnaLibraryFastqs.sh
+++ b/fetchEnaLibraryFastqs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash 
 
-usage() { echo "Usage: $0 -l <library> -d <output directory> [-m <retrieval method, default 'wget'>] [-s <source directory for method 'dir'>] [-p <public or private, default public>] [-c <config file to override defaults>] [-t <download type, fastq or srr>]" 1>&2; }
+usage() { echo "Usage: $0 -l <library> -d <output directory> [-m <retrieval method, default 'wget'>] [-s <source directory for method 'dir'>] [-p <public or private, default public>] [-c <config file to override defaults>] [-t <download type, fastq or srr>] [-n <SINGLE or PAIRED, default PAIRED>]" 1>&2; }
 
 # Parse arguments
 
@@ -10,6 +10,7 @@ m=auto
 s=
 p=public
 t=fastq
+n=PAIRED
 
 while getopts ":l:d:m:s:p:c:t:" o; do
     case "${o}" in
@@ -33,6 +34,9 @@ while getopts ":l:d:m:s:p:c:t:" o; do
             ;;
         t)
             t=${OPTARG}
+            ;;
+        n)
+            n=${OPTARG}
             ;;
         *)
             usage
@@ -61,6 +65,7 @@ fileSource=$s
 status=$p
 configFile=$c
 downloadType=$t
+sepe=$n
 
 if [ ! -z "$configFile" ]; then
     source $configFile
@@ -71,7 +76,7 @@ if [ "$method" == 'dir' ]; then
 elif [ "$downloadType" == 'srr' ]; then
     fetch_library_files_from_sra_file $library $outputDir $ENA_RETRIES $method $status
 else
-    fetch_library_files_from_ena $library $outputDir $ENA_RETRIES $method $status
+    fetch_library_files_from_ena $library $outputDir $ENA_RETRIES $method $status $sepe
 fi
 
 fetchStatus=$?

--- a/fetchEnaLibraryFastqs.sh
+++ b/fetchEnaLibraryFastqs.sh
@@ -12,7 +12,7 @@ p=public
 t=fastq
 n=PAIRED
 
-while getopts ":l:d:m:s:p:c:t:" o; do
+while getopts ":l:d:m:s:p:c:t:n:" o; do
     case "${o}" in
         l)
             l=${OPTARG}

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -6,4 +6,5 @@ channels:
 dependencies:
   - bats
   - coreutils
-  - sra-tools  
+  - sra-tools
+  - grep

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -5,6 +5,7 @@ channels:
   - defaults
 dependencies:
   - bats
+  - grep
   - coreutils
   - sra-tools
-  - bash
+  - fastq_utils

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -7,3 +7,4 @@ dependencies:
   - bats
   - coreutils
   - sra-tools
+  - bash

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -7,4 +7,3 @@ dependencies:
   - bats
   - coreutils
   - sra-tools
-  - grep


### PR DESCRIPTION
The goal here is to  bring logic to check FASTQ files (single-end or paired-end) to atlas-fastq-provider. This logic was previously in a [script ](https://github.com/ebi-gene-expression-group/isl/blob/develop/fetch_fastqs_from_ENA.sh)of the ISL repo.

I have added a simple script to deinterleave fastq files (the one referred to in the ISL script is not there anymore), but as ENA has stopped accepting interleaved FASTQ files we could also ignore this part. Actually, it could be the best to skip the deinterleave process with an error if only one .fastq.gz is found when PAIRED-end is specified, as it seems the deinterleave script can process genuine SINGLE-end experiments.

I had to add `grep` as test dependency to avoid errors in macOS. Apparently, a gnu compatible grep version installed is necessary for mac os x.